### PR TITLE
Fix inventory kick when updated too quickly

### DIFF
--- a/src/main/java/me/dniym/listeners/pLisbListener.java
+++ b/src/main/java/me/dniym/listeners/pLisbListener.java
@@ -40,8 +40,10 @@ public class pLisbListener {
                             try {
                                 ItemStack stack = event.getPacket().getItemModifier().readSafely(0);
                                 if (stack != null && stack.hasItemMeta()) {
-                                    stack = new ItemStack(Material.AIR);
-                                    event.getPlayer().updateInventory();
+
+                                    final Player player = event.getPlayer();
+                                    plugin.getServer().getScheduler().runTaskLater(plugin, player::updateInventory, 5L);
+
                                     event.setCancelled(true);
                                     Msg.StaffMsgCreativeBlock.getValue(event.getPlayer().getName());
                                 }


### PR DESCRIPTION
The issue arises when running an 1.12.2 server with both IllegalStack and ViaVersion, and trying to take an item with metadata (such as a potion) from the inventory. The player will be kicked with a weird IOException.