### PR TITLE
Fix a dispenser-shulker crash

### DIFF
--- a/src/main/java/me/dniym/listeners/fListener.java
+++ b/src/main/java/me/dniym/listeners/fListener.java
@@ -640,7 +640,7 @@ public class fListener implements Listener {
 			return;
 
 		if(Protections.PreventShulkerCrash.isEnabled()) {
-			if(e.getBlock().getLocation().getY() >= 255 && e.getItem().getType().name().endsWith("SHULKER_BOX")) {
+			if(e.getBlock().getLocation().getY() >= 255 || if(e.getBlock().getLocation().getY() == 0 && e.getItem().getType().name().endsWith("SHULKER_BOX")) {
 				e.setCancelled(true);
 			}
 		}

--- a/src/main/java/me/dniym/listeners/fListener.java
+++ b/src/main/java/me/dniym/listeners/fListener.java
@@ -640,7 +640,7 @@ public class fListener implements Listener {
 			return;
 
 		if(Protections.PreventShulkerCrash.isEnabled()) {
-			if(e.getBlock().getLocation().getY() >= 255 || if(e.getBlock().getLocation().getY() == 0 && e.getItem().getType().name().endsWith("SHULKER_BOX")) {
+			if((e.getBlock().getLocation().getY() >= 255 || if(e.getBlock().getLocation().getY() == 0) && e.getItem().getType().name().endsWith("SHULKER_BOX")) {
 				e.setCancelled(true);
 			}
 		}


### PR DESCRIPTION
This should fix a server crash when activating a dispenser with a full shulker box at Y level 0.