### PR TITLE
Fix another variation of the dispenser-shulker crash

### DIFF
--- a/src/main/java/me/dniym/listeners/fListener.java
+++ b/src/main/java/me/dniym/listeners/fListener.java
@@ -640,11 +640,11 @@ public class fListener implements Listener {
 			return;
 
 		if(Protections.PreventShulkerCrash.isEnabled()) {
-			if((e.getBlock().getLocation().getY() >= 255 || if(e.getBlock().getLocation().getY() == 0) && e.getItem().getType().name().endsWith("SHULKER_BOX")) {
+			if((e.getBlock().getLocation().getY() >= 255 || (e.getBlock().getLocation().getY() == 0)) && e.getItem().getType().name().endsWith("SHULKER_BOX")) {
 				e.setCancelled(true);
 			}
 		}
-		
+
 		if(Protections.PreventShulkerCrash2.isEnabled() && e.getItem().getType() == Material.FLINT_AND_STEEL) {
 			if (e.getBlock().getState().getBlockData() instanceof Directional) {
 				Directional d = (Directional) e.getBlock().getState().getBlockData();

--- a/src/main/java/me/dniym/listeners/fListener.java
+++ b/src/main/java/me/dniym/listeners/fListener.java
@@ -640,7 +640,7 @@ public class fListener implements Listener {
 			return;
 
 		if(Protections.PreventShulkerCrash.isEnabled()) {
-			if(e.getBlock().getLocation().getY() >= 255 && e.getItem().getType().name().endsWith("SHULKER_BOX")) {
+			if(e.getBlock().getLocation().getY() >= 255 || if(e.getBlock().getLocation().getY() == 0 && e.getItem().getType().name().endsWith("SHULKER_BOX")) {
 				e.setCancelled(true);
 			}
 		}

--- a/src/main/java/me/dniym/listeners/fListener.java
+++ b/src/main/java/me/dniym/listeners/fListener.java
@@ -640,7 +640,7 @@ public class fListener implements Listener {
 			return;
 
 		if(Protections.PreventShulkerCrash.isEnabled()) {
-			if(e.getBlock().getLocation().getY() >= 255 || if(e.getBlock().getLocation().getY() == 0 && e.getItem().getType().name().endsWith("SHULKER_BOX")) {
+			if((e.getBlock().getLocation().getY() >= 255 || if(e.getBlock().getLocation().getY() == 0) && e.getItem().getType().name().endsWith("SHULKER_BOX")) {
 				e.setCancelled(true);
 			}
 		}


### PR DESCRIPTION
This prevents people from using dispensers with full shulkers inside at Y level 0 to crash the server, tested on git-Paper-1618 (MC: 1.12.2).

Sorry for my previous PR which did not work. I do not program in Java.