### PR TITLE
Optimize nether roof movement

### DIFF
--- a/src/main/java/me/dniym/listeners/fListener.java
+++ b/src/main/java/me/dniym/listeners/fListener.java
@@ -3080,11 +3080,9 @@ public class fListener implements Listener {
 
 	@EventHandler
 	public void NetherCeilingMovementCheck(PlayerMoveEvent e) {
-		if (e.getPlayer().isOp() || e.getPlayer().hasPermission("illegalstack.notify")) 
-			return;
-
-
-		if (e.getFrom().getBlockX() == e.getTo().getBlockX() && e.getFrom().getBlockY() == e.getTo().getBlockY() && e.getFrom().getBlockZ() == e.getTo().getBlockZ())
+		if (e.getFrom().getBlockX() == e.getTo().getBlockX() && e.getFrom().getBlockY() == e.getTo().getBlockY() && e.getFrom().getBlockZ() == e.getTo().getBlockZ()
+			|| e.getPlayer().isOp()
+			|| e.getPlayer().hasPermission("illegalstack.notify"))
 			return;
 
 		if (Protections.KillPlayersBelowNether.isEnabled() && 


### PR DESCRIPTION
Only checks for permission and op if a player moves over a block now