### PR TITLE
Fix of shutdown error

### DIFF
--- a/src/main/java/main/java/me/dniym/IllegalStack.java
+++ b/src/main/java/main/java/me/dniym/IllegalStack.java
@@ -22,6 +22,7 @@ import org.bukkit.World;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;

--- a/src/main/java/main/java/me/dniym/IllegalStack.java
+++ b/src/main/java/main/java/me/dniym/IllegalStack.java
@@ -22,7 +22,6 @@ import org.bukkit.World;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;

--- a/src/main/java/main/java/me/dniym/IllegalStack.java
+++ b/src/main/java/main/java/me/dniym/IllegalStack.java
@@ -932,8 +932,15 @@ public class IllegalStack extends JavaPlugin {
         }
     }
 
+    private static boolean disable=false;
+
+    public static boolean isDisable() {
+        return disable;
+    }
+
     @Override
     public void onDisable() {
+        disable=true;
     	if(hasAsyncScheduler) {
             getServer().getAsyncScheduler().cancelTasks(this);
         }else {

--- a/src/main/java/main/java/me/dniym/timers/fTimer.java
+++ b/src/main/java/main/java/me/dniym/timers/fTimer.java
@@ -119,7 +119,9 @@ public class fTimer implements Runnable {
 
     @Override
     public void run() {
-
+        if(IllegalStack.isDisable()){
+            return;
+        }
         for (Player p : punish.keySet()) {
             Scheduler.executeOrScheduleSync(plugin, () -> fListener.punishPlayer(p, punish.get(p)), p);
         }

--- a/src/main/java/main/java/me/dniym/timers/fTimer.java
+++ b/src/main/java/main/java/me/dniym/timers/fTimer.java
@@ -119,7 +119,7 @@ public class fTimer implements Runnable {
 
     @Override
     public void run() {
-        if(IllegalStack.isDisable()){
+        if(IllegalStack.isDisable()|| Bukkit.getServer().isStopping()){
             return;
         }
         for (Player p : punish.keySet()) {
@@ -128,7 +128,7 @@ public class fTimer implements Runnable {
         punish.clear();
 
         if (Protections.DamagePlayersAboveNether.isEnabled() && System.currentTimeMillis() >= nextNetherDamage) {
-        	 nextNetherDamage = System.currentTimeMillis() + (Protections.AboveNetherDamageDelay.getIntValue() * 1000);
+        	 nextNetherDamage = System.currentTimeMillis() + (Protections.AboveNetherDamageDelay.getIntValue() * 1000L);
         	for(World w:plugin.getServer().getWorlds())
         		if(w.getName().toLowerCase().contains("nether") || w.getEnvironment() == Environment.NETHER)
         			for(Player p:w.getPlayers())

--- a/src/main/java/main/java/me/dniym/timers/sTimer.java
+++ b/src/main/java/main/java/me/dniym/timers/sTimer.java
@@ -8,6 +8,7 @@ import main.java.me.dniym.utils.Scheduler;
 import net.md_5.bungee.api.ChatColor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
@@ -63,10 +64,10 @@ public class sTimer implements Runnable {
 
     @Override
     public void run() {
-        if (!Protections.DestroyBadSignsonChunkLoad.isEnabled() || Protections.DestroyBadSignsonChunkLoad.notifyOnly()) {
+        if(IllegalStack.isDisable()|| Bukkit.getServer().isStopping()){
             return;
         }
-        if(IllegalStack.isDisable()){
+        if (!Protections.DestroyBadSignsonChunkLoad.isEnabled() || Protections.DestroyBadSignsonChunkLoad.notifyOnly()) {
             return;
         }
         if (getSignCheck() != -1L && System.currentTimeMillis() >= getSignCheck()) {

--- a/src/main/java/main/java/me/dniym/timers/sTimer.java
+++ b/src/main/java/main/java/me/dniym/timers/sTimer.java
@@ -63,8 +63,10 @@ public class sTimer implements Runnable {
 
     @Override
     public void run() {
-
         if (!Protections.DestroyBadSignsonChunkLoad.isEnabled() || Protections.DestroyBadSignsonChunkLoad.notifyOnly()) {
+            return;
+        }
+        if(IllegalStack.isDisable()){
             return;
         }
         if (getSignCheck() != -1L && System.currentTimeMillis() >= getSignCheck()) {

--- a/src/main/java/main/java/me/dniym/timers/syncTimer.java
+++ b/src/main/java/main/java/me/dniym/timers/syncTimer.java
@@ -23,7 +23,8 @@ public class syncTimer implements Runnable {
 
 	@Override
 	public void run() {
-
+		if(IllegalStack.isDisable())
+			return;
 		if(System.currentTimeMillis() >= nextScan) {
 			TrackedProjectile.manage();
 		}


### PR DESCRIPTION
Fix of constantly running tasks during the shutdown of the plugin (reported on Discord by _.eagl3)

This issue can occur, if you have quite a lot of plugins on your server and your shutdown time is longer than 20-25 seconds.
During this time, player's arent kicked (most of the time) from the server which makes them available for the method Bukkit.getOnlinePlayers() but the server stops accepting new tasks while it's disabling. That's why it's needed to stop the creation of new tasks by implementing simple check like I've did.