### PR TITLE
Improve HopperXfer performance

### DIFF
--- a/src/main/java/main/java/me/dniym/checks/CheckUtils.java
+++ b/src/main/java/main/java/me/dniym/checks/CheckUtils.java
@@ -108,8 +108,7 @@ public class CheckUtils {
 
     public static boolean CheckEntireInventory(Inventory inv) {
 
-        for (int i = 0; i < inv.getContents().length; i++) {
-            ItemStack is = inv.getContents()[i];
+        for (ItemStack is : inv.getContents()) {
             if (is == null) {
                 continue;
             }

--- a/src/main/java/main/java/me/dniym/listeners/mcMMOListener.java
+++ b/src/main/java/main/java/me/dniym/listeners/mcMMOListener.java
@@ -30,8 +30,9 @@ public class mcMMOListener implements Listener {
     @EventHandler
     public void onPotionBrew(McMMOPlayerBrewEvent e) {
         BrewingStand bs =(BrewingStand) e.getBrewingStand();
-        for(int i = 0; i < bs.getInventory().getStorageContents().length;i++) {
-            ItemStack is = bs.getInventory().getStorageContents()[i];
+        ItemStack[] storageContents = bs.getInventory().getStorageContents();
+        for(int i = 0; i < storageContents.length;i++) {
+            ItemStack is = storageContents[i];
 
             if(is == null)
                 continue;


### PR DESCRIPTION
Inventory#getContents() is expensive and it was being called unnecessarily.
I've also modified the mcMMOListener in the same manner, altough it's commented (I don't know why), to prevent this happening in the future.
This PR has been benchmarked and used in production for a long time, the performance improvements on the check were well above 10x.