### PR TITLE
Added 1.20.6 support.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,13 +44,13 @@ dependencies {
     compileOnly("com.elmakers.mine.bukkit:MagicAPI:10.2")
     compileOnly("de.tr7zw:item-nbt-api-plugin:2.8.0")
     compileOnly("com.github.TheBusyBiscuit:Slimefun4:RC-30") { isTransitive = false }
-    compileOnly("io.netty:netty-all:4.1.82.Final") {
+    compileOnly("io.netty:netty-all:4.1.110.Final") {
         because("The version aligns with the version used by Minecraft itself." +
                 "The minecraft server ships netty as well, so we don't need to include it in the jar.")
     }
     compileOnly("com.gmail.nossr50.mcMMO:mcMMO:2.1.217") { isTransitive = false }
     compileOnly("fr.minuskube.inv:smart-invs:1.2.7")
-    compileOnly("com.github.CraftingStore:MinecraftPlugin:master-SNAPSHOT")
+    //compileOnly("com.github.CraftingStore.MinecraftPlugin:core:master-e366d322f8-1")
     compileOnly("com.github.brcdev-minecraft:shopgui-api:3.0.0")
 }
 
@@ -66,7 +66,7 @@ tasks.compileJava.configure {
     options.release.set(8)
 }
 
-version = "2.9.10-SNAPSHOT-02"
+version = "2.9.11-SNAPSHOT-01"
 
 tasks.named<Copy>("processResources") {
     filesMatching("plugin.yml") {

--- a/src/main/java/main/java/me/dniym/enums/Protections.java
+++ b/src/main/java/main/java/me/dniym/enums/Protections.java
@@ -1,6 +1,7 @@
 package main.java.me.dniym.enums;
 
 
+import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.UnsupportedCharsetException;
@@ -26,6 +27,7 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.BlockInventoryHolder;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -37,7 +39,6 @@ import main.java.me.dniym.utils.SpigotMethods;
 //import me.jet315.minions.MinionAPI;
 //import me.jet315.minions.minions.Minion;
 import net.brcdev.shopgui.gui.gui.OpenGui;
-import net.craftingstore.bukkit.inventory.CraftingStoreInventoryHolder;
 
 public enum Protections {
 
@@ -1294,7 +1295,6 @@ public enum Protections {
             false
             )
     ;
-
     private static final Logger LOGGER = LogManager.getLogger("IllegalStack/" + Protections.class.getSimpleName());
     ///OPTIONS///
     private Object defaultValue = null;
@@ -1314,6 +1314,7 @@ public enum Protections {
     private boolean isList = false;
     private int catId = 0;
     private boolean relevant = false;
+    private static Class<?> craftingStoreInventoryHolder = null;
 
     Protections(
             int id,
@@ -1692,34 +1693,33 @@ public enum Protections {
     }
 
     private String getServerVersion() {
-        if (serverVersion == "") {
-            String version = IllegalStack
-                    .getPlugin()
-                    .getServer()
-                    .getClass()
-                    .getPackage()
-                    .getName()
-                    .replace(".", ",")
-                    .split(",")[3];
-
-
-            version = IllegalStack.getString(version);
-            if (version.equalsIgnoreCase("v1_15_R1")) {
-
-                version = IllegalStack.getPlugin().getServer().getVersion().split(" ")[2];
-                if (version.contains(" ")) {
-                    version = version.replace(")", "");
-                    version = version.replace(".", "_");
-                    String[] ver = version.split("_");
-                    version = "v" + ver[0] + "_" + ver[1] + "_R" + ver[2];
-                }
-
-            }
-
-            serverVersion = version;
-
-        }
-        return serverVersion;
+//        if (serverVersion.equalsIgnoreCase("")) {
+//            String version = IllegalStack
+//                    .getPlugin()
+//                    .getServer()
+//                    .getClass()
+//                    .getPackage()
+//                    .getName()
+//                    .replace(".", ",")
+//                    .split(",")[3];
+//
+//
+//            version = IllegalStack.getString(version);
+//            if (version.equalsIgnoreCase("v1_15_R1")) {
+//
+//                version = IllegalStack.getPlugin().getServer().getVersion().split(" ")[2];
+//                if (version.contains(" ")) {
+//                    version = version.replace(")", "");
+//                    version = version.replace(".", "_");
+//                    String[] ver = version.split("_");
+//                    version = "v" + ver[0] + "_" + ver[1] + "_R" + ver[2];
+//                }
+//
+//            }
+//
+//            serverVersion = version;
+//        }
+        return IllegalStack.getVersion();
     }
 
     public boolean notifyOnly() {
@@ -2442,11 +2442,26 @@ public enum Protections {
         return false;
     }
 
+    public static void runReflectionChecks() {
+        try {
+            craftingStoreInventoryHolder = Class.forName("net.craftingstore.bukkit.inventory.CraftingStoreInventoryHolder");
+            LOGGER.info("CraftingStore plugin detected!  IllegalStack will now be able to detect and handle CraftingStore inventories.");
+        } catch (ClassNotFoundException e) {
+            craftingStoreInventoryHolder = null;
+        }
+    }
 
     public boolean isThirdPartyInventory(InventoryView inv) {
 
         if (IllegalStack.getPlugin().getServer().getPluginManager().getPlugin("CraftingStore") != null) {
-            if (inv.getTopInventory().getHolder() instanceof CraftingStoreInventoryHolder) {
+            if (craftingStoreInventoryHolder == null) {
+                return false;
+            }
+            InventoryHolder holder = inv.getTopInventory().getHolder();
+            if (holder == null) {
+                return false;
+            }
+            if (inv.getTopInventory().getHolder().getClass() == craftingStoreInventoryHolder) {
                 return true;
             }
 

--- a/src/main/java/main/java/me/dniym/enums/ServerVersion.java
+++ b/src/main/java/main/java/me/dniym/enums/ServerVersion.java
@@ -1,0 +1,59 @@
+package main.java.me.dniym.enums;
+
+public enum ServerVersion {
+
+    v1_8_R1,
+    v1_8_R2,
+    v1_8_R3,
+    v1_9_R1,
+    v1_9_R2,
+    v1_10_R1,
+    v1_11_R1,
+    v1_12_R1,
+    v1_13_R1,
+    v1_13_R2,
+    v1_14_R1,
+    v1_15_R1,
+    v1_16_R1,
+    v1_16_R2,
+    v1_16_R3,
+    v1_17_R1,
+    v1_18_R1,
+    v1_18_R2,
+    v1_19_R1,
+    v1_19_R2,
+    v1_19_R3,
+    v1_20_R1,
+    v1_20_R2,
+    v1_20_R3,
+    v1_20_R4;
+
+    public boolean serverVersionEqual(ServerVersion version) {
+        return this.equals(version);
+    }
+
+    public boolean serverVersionGreaterThanOrEqual(ServerVersion version) {
+        return this.ordinal() >= version.ordinal();
+    }
+
+
+    public boolean serverVersionGreaterThan(ServerVersion version1, ServerVersion version2) {
+        return version1.ordinal() > version2.ordinal();
+    }
+
+    public boolean serverVersionLessThan(ServerVersion version1, ServerVersion version2) {
+        return version1.ordinal() < version2.ordinal();
+    }
+
+    public String getServerVersionName() {
+        return this.name();
+    }
+
+    public int getOrdinalServerVersionNumber() {
+        return this.ordinal();
+    }
+
+    public int getServerMajorVersionNumber() {
+        return Integer.parseInt(this.name().split("_")[1]);
+    }
+}

--- a/src/main/java/main/java/me/dniym/timers/fTimer.java
+++ b/src/main/java/main/java/me/dniym/timers/fTimer.java
@@ -6,6 +6,7 @@ import main.java.me.dniym.checks.BadAttributeCheck;
 import main.java.me.dniym.checks.BadPotionCheck;
 import main.java.me.dniym.enums.Msg;
 import main.java.me.dniym.enums.Protections;
+import main.java.me.dniym.enums.ServerVersion;
 import main.java.me.dniym.listeners.fListener;
 import main.java.me.dniym.listeners.mcMMOListener;
 import main.java.me.dniym.util.TrackedProjectile;
@@ -81,8 +82,7 @@ public class fTimer implements Runnable {
         }
 
 
-        String version = plugin.getServer().getClass().getPackage().getName().replace(".", ",")
-                .split(",")[3];
+        String version = IllegalStack.getVersion();
         is1_8 = version.equalsIgnoreCase("v1_8_R3") || version.contains("v1_8");
 
         if (is1_8) {
@@ -123,7 +123,8 @@ public class fTimer implements Runnable {
     @Override
     public void run() {
 
-        if (!IllegalStack.isIsHybridEnvironment()) {
+        if (!IllegalStack.isIsHybridEnvironment() && IllegalStack.isPaperServer()
+                && IllegalStack.getMajorServerVersion() >= 16) {
             if (IllegalStack.isDisable() || Bukkit.getServer().isStopping()) {
                 return;
             }

--- a/src/main/java/main/java/me/dniym/timers/sTimer.java
+++ b/src/main/java/main/java/me/dniym/timers/sTimer.java
@@ -3,6 +3,7 @@ package main.java.me.dniym.timers;
 import main.java.me.dniym.IllegalStack;
 import main.java.me.dniym.enums.Msg;
 import main.java.me.dniym.enums.Protections;
+import main.java.me.dniym.enums.ServerVersion;
 import main.java.me.dniym.listeners.fListener;
 import main.java.me.dniym.utils.Scheduler;
 import net.md_5.bungee.api.ChatColor;
@@ -65,7 +66,8 @@ public class sTimer implements Runnable {
     @Override
     public void run() {
 
-        if (!IllegalStack.isIsHybridEnvironment()) {
+        if (!IllegalStack.isIsHybridEnvironment() && IllegalStack.isPaperServer()
+                && IllegalStack.getMajorServerVersion() >= 16) {
             if (IllegalStack.isDisable() || Bukkit.getServer().isStopping()) {
                 return;
             }

--- a/src/main/java/main/java/me/dniym/timers/syncTimer.java
+++ b/src/main/java/main/java/me/dniym/timers/syncTimer.java
@@ -25,7 +25,8 @@ public class syncTimer implements Runnable {
     @Override
     public void run() {
 
-        if (!IllegalStack.isIsHybridEnvironment()) {
+        if (!IllegalStack.isIsHybridEnvironment() && IllegalStack.isPaperServer()
+                && IllegalStack.getMajorServerVersion() >= 16) {
             if (IllegalStack.isDisable() || Bukkit.getServer().isStopping()) {
                 return;
             }


### PR DESCRIPTION
Added 1.20.6 support.
Streamlined server version checking. 
Added startup checks to look for Paper server environment. 
Implemented reflection checks for CraftingStore plugin hooks. 
Updated NettyIO to latest version.
Changed version to `2.9.11-SNAPSHOT-01`.