### PR TITLE
1.21 support & Bug Fixes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("dev.folia:folia-api:1.20.2-R0.1-SNAPSHOT")
+    compileOnly("dev.folia:folia-api:1.20.4-R0.1-SNAPSHOT")
     compileOnly("com.comphenix.protocol:ProtocolLib:5.0.0")
     compileOnly("com.elmakers.mine.bukkit:MagicAPI:10.2")
     compileOnly("de.tr7zw:item-nbt-api-plugin:2.8.0")
@@ -66,7 +66,7 @@ tasks.compileJava.configure {
     options.release.set(8)
 }
 
-version = "2.9.11-SNAPSHOT-01"
+version = "2.9.12-SNAPSHOT-01"
 
 tasks.named<Copy>("processResources") {
     filesMatching("plugin.yml") {

--- a/src/main/java/main/java/me/dniym/IllegalStack.java
+++ b/src/main/java/main/java/me/dniym/IllegalStack.java
@@ -45,6 +45,7 @@ public class IllegalStack extends JavaPlugin {
     private static Plugin ProCosmetics = null;
     private static boolean isHybridEnvironment = false;
     private static boolean isPaperServer = false;
+    private static boolean isFoliaServer = false;
     private static boolean hasProtocolLib = false;
     private static boolean hasAttribAPI = false;
     private static boolean nbtAPI = false;
@@ -97,6 +98,10 @@ public class IllegalStack extends JavaPlugin {
 
     public static boolean isSpigot() {
         return Spigot;
+    }
+
+    public static boolean isFoliaServer() {
+        return isFoliaServer;
     }
 
     public static boolean isCMI() {
@@ -164,10 +169,22 @@ public class IllegalStack extends JavaPlugin {
         }
     }
 
+    private static void checkForFoliaServer() {
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            isFoliaServer = true;
+            LOGGER.info("Server has Folia components, enabling Folia features.");
+        } catch (ClassNotFoundException e) {
+            isFoliaServer = false;
+            LOGGER.info("Server does NOT have Folia components, continuing as normal.");
+        }
+    }
+
     private static void StartupPlugin() {
 
         checkForHybridEnvironment();
         checkForPaperServer();
+        checkForFoliaServer();
 
         try {
             Class.forName("org.spigotmc.SpigotConfig");
@@ -424,6 +441,7 @@ public class IllegalStack extends JavaPlugin {
         loadMsgs();
         checkForHybridEnvironment();
         checkForPaperServer();
+        checkForFoliaServer();
         IllegalStackCommand illegalStackCommand = new IllegalStackCommand();
         this.getCommand("istack").setExecutor(illegalStackCommand);
         this.getCommand("istack").setTabCompleter(illegalStackCommand);
@@ -1018,7 +1036,7 @@ public class IllegalStack extends JavaPlugin {
         disable = true;
         if (hasAsyncScheduler) {
             getServer().getAsyncScheduler().cancelTasks(this);
-        } else {
+        } else if (!isFoliaServer()){
             Bukkit.getScheduler().cancelTasks(this);
         }
 
@@ -1119,8 +1137,12 @@ public class IllegalStack extends JavaPlugin {
         } else {
             String packageName = Bukkit.getServer().getClass().getPackage().getName();
             String bukkitVersion = Bukkit.getServer().getBukkitVersion();
-            if (bukkitVersion.contains("1.20.5") || bukkitVersion.contains("1.20.6")) {
-                serverVersion = ServerVersion.v1_20_R4;
+            if (bukkitVersion.contains("1.20.5")) {
+                serverVersion = ServerVersion.v1_20_R5;
+            } else if (bukkitVersion.contains("1.20.6")) {
+                serverVersion = ServerVersion.v1_20_R5;
+            } else if (bukkitVersion.contains("1.21")) {
+                serverVersion = ServerVersion.v1_21_R1;
             } else {
                 serverVersion = ServerVersion.valueOf(packageName.replace("org.bukkit.craftbukkit.", ""));
             }

--- a/src/main/java/main/java/me/dniym/enums/ServerVersion.java
+++ b/src/main/java/main/java/me/dniym/enums/ServerVersion.java
@@ -26,7 +26,9 @@ public enum ServerVersion {
     v1_20_R1,
     v1_20_R2,
     v1_20_R3,
-    v1_20_R4;
+    v1_20_R4,
+    v1_20_R5,
+    v1_21_R1;
 
     public boolean serverVersionEqual(ServerVersion version) {
         return this.equals(version);


### PR DESCRIPTION
- Added 1.21.0 support. 
- Updated FoliaAPI to `1.20.4`. 
- Added check for Folia server on startup. 
- Fixed Folia shutdown scheduler error. 
- Changed version to `2.9.12-SNAPSHOT-01`.